### PR TITLE
Update FlickeringEmissive.cs

### DIFF
--- a/Assets/Scripts/FlickeringEmissive.cs
+++ b/Assets/Scripts/FlickeringEmissive.cs
@@ -28,7 +28,7 @@ public class FlickeringEmissive : MonoBehaviour
 
         foreach (Material material in Renderer.materials)
         {
-            if (Renderer.material.enabledKeywords.Any(item => item.name == EMISSIVE_KEYWORD)
+            if (material.enabledKeywords.Any(item => item.name == EMISSIVE_KEYWORD)
                 && Renderer.material.HasColor(EMISSIVE_COLOR_NAME))
             {
                 Materials.Add(material);


### PR DESCRIPTION
It was pointed out this only works if the FIRST material on an object had the emissive property. With this change it will address that issue!